### PR TITLE
Add fr-fr locale

### DIFF
--- a/locale/fr-fr/RandomKeyword.voc
+++ b/locale/fr-fr/RandomKeyword.voc
@@ -1,0 +1,2 @@
+aléatoire
+au hasard

--- a/locale/fr-fr/next.voc
+++ b/locale/fr-fr/next.voc
@@ -1,0 +1,2 @@
+après
+suivant

--- a/locale/fr-fr/no.more.pictures.dialog
+++ b/locale/fr-fr/no.more.pictures.dialog
@@ -1,0 +1,2 @@
+Je n'ai plus d'images à afficher.
+Je n'ai plus d'images sous la main.

--- a/locale/fr-fr/picture.about.intent
+++ b/locale/fr-fr/picture.about.intent
@@ -1,0 +1,6 @@
+affiche une image de {query}
+affiche une photo de {query}
+montre-moi une image de {query}
+montre-moi une photo de {query}
+affiche une autre image de {query}
+montre-moi une nouvelle image de {query}

--- a/locale/fr-fr/picture.random.intent
+++ b/locale/fr-fr/picture.random.intent
@@ -1,0 +1,6 @@
+affiche une image
+affiche une photo
+montre-moi une image
+montre-moi une photo
+affiche une autre image
+montre-moi une nouvelle image

--- a/locale/fr-fr/previous.voc
+++ b/locale/fr-fr/previous.voc
@@ -1,0 +1,3 @@
+avant
+précédent
+reviens en arrière

--- a/locale/fr-fr/searching.dialog
+++ b/locale/fr-fr/searching.dialog
@@ -1,0 +1,2 @@
+Je cherche des images sur {query}.
+Je cherche des photos de {query}.

--- a/locale/fr-fr/searching_random.dialog
+++ b/locale/fr-fr/searching_random.dialog
@@ -1,0 +1,2 @@
+D'accord, je cherche des images.
+Très bien, je cherche des photos.

--- a/locale/fr-fr/set.voc
+++ b/locale/fr-fr/set.voc
@@ -1,0 +1,3 @@
+applique
+mets
+utilise

--- a/locale/fr-fr/skill.json
+++ b/locale/fr-fr/skill.json
@@ -1,0 +1,22 @@
+{
+  "skill_id": "skill-ovos-wallpapers.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/skill-ovos-wallpapers",
+  "extra_plugins": {
+    "core": [],
+    "PHAL": ["ovos-PHAL-plugin-wallpaper-manager"],
+    "listener": [],
+    "audio": [],
+    "media": [],
+    "gui": []
+  },
+  "name": "Fonds d'écran",
+  "description": "Des images issues de sources sélectionnées.",
+  "examples": [
+    "un nouveau fond d'écran",
+    "change le fond d'écran pour la nature",
+    "montre-moi une image",
+    "montre-moi une image de chiens",
+    "mets cette image en fond d'écran"
+  ],
+  "tags": ["wallpapers", "images", "pictures"]
+}

--- a/locale/fr-fr/wallpaper.about.intent
+++ b/locale/fr-fr/wallpaper.about.intent
@@ -1,0 +1,4 @@
+change le fond d'écran pour {query}
+change le fond d'écran en {query}
+mets un fond d'écran sur {query}
+mets un fond d'écran de {query}

--- a/locale/fr-fr/wallpaper.changed.dialog
+++ b/locale/fr-fr/wallpaper.changed.dialog
@@ -1,0 +1,2 @@
+Profitez de votre nouveau fond d'écran.
+Votre fond d'écran a été changé.

--- a/locale/fr-fr/wallpaper.fail.dialog
+++ b/locale/fr-fr/wallpaper.fail.dialog
@@ -1,0 +1,1 @@
+Je ne sais pas changer le fond d'écran sur cette plateforme.

--- a/locale/fr-fr/wallpaper.random.intent
+++ b/locale/fr-fr/wallpaper.random.intent
@@ -1,0 +1,4 @@
+change le fond d'écran
+nouveau fond d'écran
+mets un autre fond d'écran
+change le fond d'écran actuel

--- a/locale/fr-fr/wallpapers.voc
+++ b/locale/fr-fr/wallpapers.voc
@@ -1,0 +1,2 @@
+fond d'écran
+fonds d'écran

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -1,0 +1,21 @@
+{
+    "no.more.pictures.dialog": [
+        "Je n'ai plus d'images \u00e0 afficher.",
+        "Je n'ai plus d'images sous la main."
+    ],
+    "searching.dialog": [
+        "Je cherche des images sur {query}.",
+        "Je cherche des photos de {query}."
+    ],
+    "searching_random.dialog": [
+        "D'accord, je cherche des images.",
+        "Tr\u00e8s bien, je cherche des photos."
+    ],
+    "wallpaper.changed.dialog": [
+        "Profitez de votre nouveau fond d'\u00e9cran.",
+        "Votre fond d'\u00e9cran a \u00e9t\u00e9 chang\u00e9."
+    ],
+    "wallpaper.fail.dialog": [
+        "Je ne sais pas changer le fond d'\u00e9cran sur cette plateforme."
+    ]
+}

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,0 +1,30 @@
+{
+    "picture.about.intent": [
+        "affiche une image de {query}",
+        "affiche une photo de {query}",
+        "montre-moi une image de {query}",
+        "montre-moi une photo de {query}",
+        "affiche une autre image de {query}",
+        "montre-moi une nouvelle image de {query}"
+    ],
+    "picture.random.intent": [
+        "affiche une image",
+        "affiche une photo",
+        "montre-moi une image",
+        "montre-moi une photo",
+        "affiche une autre image",
+        "montre-moi une nouvelle image"
+    ],
+    "wallpaper.about.intent": [
+        "change le fond d'\u00e9cran pour {query}",
+        "change le fond d'\u00e9cran en {query}",
+        "mets un fond d'\u00e9cran sur {query}",
+        "mets un fond d'\u00e9cran de {query}"
+    ],
+    "wallpaper.random.intent": [
+        "change le fond d'\u00e9cran",
+        "nouveau fond d'\u00e9cran",
+        "mets un autre fond d'\u00e9cran",
+        "change le fond d'\u00e9cran actuel"
+    ]
+}

--- a/translations/fr-fr/vocabs.json
+++ b/translations/fr-fr/vocabs.json
@@ -1,0 +1,24 @@
+{
+    "RandomKeyword.voc": [
+        "al\u00e9atoire",
+        "au hasard"
+    ],
+    "next.voc": [
+        "apr\u00e8s",
+        "suivant"
+    ],
+    "previous.voc": [
+        "avant",
+        "pr\u00e9c\u00e9dent",
+        "reviens en arri\u00e8re"
+    ],
+    "set.voc": [
+        "applique",
+        "mets",
+        "utilise"
+    ],
+    "wallpapers.voc": [
+        "fond d'\u00e9cran",
+        "fonds d'\u00e9cran"
+    ]
+}


### PR DESCRIPTION
## Summary
- add a complete `fr-fr` locale tree matching `en-us`
- add the matching `translations/fr-fr` snapshot files
- localize wallpaper/image prompts for French assistant use